### PR TITLE
Firebase AI Logic SDKの追加

### DIFF
--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,3 +1,4 @@
+import { GoogleAIBackend, getAI, getGenerativeModel } from "firebase/ai"
 import { getAnalytics } from "firebase/analytics"
 import { initializeApp } from "firebase/app"
 
@@ -13,6 +14,9 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig)
 const analytics = getAnalytics(app)
+const ai = getAI(app, { backend: new GoogleAIBackend() })
+const modelName = import.meta.env.VITE_FIREBASE_AI_MODEL || "gemini-2.5-flash"
+const model = getGenerativeModel(ai, { model: modelName })
 
 export default app
-export { analytics }
+export { analytics, model }


### PR DESCRIPTION
## 概要

Firebase AI Logic SDKの追加に伴う初期設定


## 変更内容

- `src/firebase.ts` でGemini APIを使用するための設定追加
- `.env` に `GEMINI_MODEL` を追加

## .envについて

今回追加した環境変数は下記の通りです。

```env
GEMINI_MODEL=gemini-2.5-flash
```

## 参考
- [Firebase AI Logic SDK を使用して Gemini API を使ってみる](https://firebase.google.com/docs/ai-logic/get-started?hl=ja&api=vertex#initialize-service-and-model)