### PR TITLE
fix: Firebase Functionsのレスポンス形式を統一

### DIFF
--- a/functions/src/handlers/dietaryRestrictionHandler.ts
+++ b/functions/src/handlers/dietaryRestrictionHandler.ts
@@ -55,7 +55,9 @@ export async function handleCheckDietaryRestrictions(
     }
     await updateMenuCollection(documentId, updatedMenuCollection)
 
-    response.sendStatus(200)
+    response.status(200).json({
+      success: true,
+    })
   } catch (error) {
     console.error("食事制限チェックでエラーが発生しました:", error)
     response.status(500).json({

--- a/functions/src/handlers/menuItemHandler.ts
+++ b/functions/src/handlers/menuItemHandler.ts
@@ -40,7 +40,9 @@ export async function handleGenerateMenuImage(request: Request, response: any): 
     }
     await updateMenuCollection(documentId, updatedMenuCollection)
 
-    response.sendStatus(200)
+    response.status(200).json({
+      success: true,
+    })
   } catch (error) {
     console.error(error)
     response.status(500).json({ success: false, error: "Internal Server Error" })


### PR DESCRIPTION
## 概要
Firebase Functionsのレスポンス形式を統一し、成功時にJSON形式で返すように変更しました。

## 変更内容
- `dietaryRestrictionHandler.ts`: `response.sendStatus(200)` を `response.status(200).json({ success: true })` に変更
- `menuItemHandler.ts`: 同様のレスポンス形式の統一

## 修正理由
- API レスポンスの一貫性を保つため
- フロントエンド側でのレスポンス処理を統一するため
- ステータスコードだけでなく、JSONでの明確な成功/失敗の判定を可能にするため

## テスト
- [ ] 食事制限チェック機能が正常に動作することを確認
- [ ] メニュー画像生成機能が正常に動作することを確認

## 影響範囲
- Firebase Functions の食事制限チェック機能
- Firebase Functions のメニュー画像生成機能